### PR TITLE
Switch to using debug.BuildInfo instead of linker vars for release info

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -2,17 +2,8 @@
 # Usage: ./release.sh [sha [tag]]
 # Builds binaries for several OSs/archs, with release info baked in via ldflags.
 
-SHA=${1:-$(git rev-parse HEAD)}
-TAG=${2:-$(git describe --exact-match --tags HEAD 2>/dev/null || echo "")}
-SHADATE=$(TZ=UTC0 git show -s --date='format-local:%Y-%m-%dT%H:%M:%SZ' --format="%cd" $SHA)
-
-RPKG=github.com/daboyuka/hs/release
-LDFLAGS=(
-  -ldflags "-X $RPKG.Tag=$TAG -X $RPKG.Commit=$SHA -X $RPKG.DateRaw=$SHADATE"
-)
-
 function mkrelease() {
-  GOOS=$1 GOARCH=$2 go build "${LDFLAGS[@]}" -o dist/hs_${1}_${2}
+  GOOS=$1 GOARCH=$2 go build -o dist/hs_${1}_${2}
 }
 
 mkrelease linux amd64

--- a/release/release.go
+++ b/release/release.go
@@ -2,37 +2,24 @@ package release
 
 import (
 	_ "embed"
-	"time"
+	"runtime/debug"
 )
 
-// These variables are the source for this build's release info. They should be overridden during build using:
+// ForkName can be overridden by forks of hs importing this package, either via init in the importing package or
+// during build using:
 //	-ldflags "-X github.com/daboyuka/hs/release.XXX=YYY"
-var (
-	Tag      string
-	Commit   string
-	DateRaw  string
-	ForkName string
-
-	// Date is DateRaw parsed as RFC3339
-	Date time.Time
-)
-
-func init() {
-	Date, _ = time.Parse(time.RFC3339, DateRaw)
-}
+var ForkName string
 
 func ReleaseName() string {
 	cmdName := "hs"
 	if ForkName != "" {
 		cmdName = "hs (" + ForkName + ")"
 	}
-	tag := Tag
-	if tag == "" {
-		commit := Commit
-		if commit == "" {
-			commit = "0000000000000000000000000000000000000000"
-		}
-		tag = "v0.0.0-" + Date.UTC().Format("20060102150405") + "-" + commit[:min(12, len(commit))] // go.mod pseudo-version format, though this is not required
+
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return cmdName + " v0.0.0-unknown"
 	}
-	return cmdName + " " + tag
+
+	return cmdName + " " + bi.Main.Version
 }


### PR DESCRIPTION
Test notes:

Without tag created (just simple commit):
```
$ hs
...
hs v0.1.16-0.20250924162433-337c92e6b06f
```

With tag created:
```
$ hs
...
hs v0.1.16
```